### PR TITLE
Update capilization of renamed items

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you find any dialogs or chat messages that don't seem to affect the charges o
 * Scythe of Vitur
 * Skull sceptre
 * Slayer staff (e)
-* Trident of the seas / swamp
+* Trident of the Seas / Swamp
 * Tumeken's shadow
 * Venator bow
   * Echo venator bow

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you find any dialogs or chat messages that don't seem to affect the charges o
 * Games necklace
 * Giantsoul amulet
 * Necklace of passage
-* Pendant of ates
+* Pendant of Ates
 * Phoenix necklace
 * Ring of dueling
 * Ring of endurance
@@ -89,9 +89,9 @@ If you find any dialogs or chat messages that don't seem to affect the charges o
 * Falador shield
 * Ghommal's hilt
 * Kharedst's memoirs / Book of the dead
-* Tome of earth
-* Tome of fire
-* Tome of water
+* Tome of Earth
+* Tome of Fire
+* Tome of Water
 
 ### Utilities
 * Ash sanctifier

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -1317,56 +1317,56 @@ public interface TicTac7xChargesImprovedConfig extends Config {
 
         @ConfigItem(
             keyName = trident_of_the_seas + _infobox,
-            name = "Trident of the seas",
+            name = "Trident of the Seas",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSeasInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_seas_e + _infobox,
-            name = "Trident of the seas (e)",
+            name = "Trident of the Seas (e)",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSeasEInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_seas_o + _infobox,
-            name = "Trident of the seas (o)",
+            name = "Trident of the Seas (o)",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSeasOInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_seas_e_o + _infobox,
-            name = "Trident of the seas (e) (o)",
+            name = "Trident of the Seas (e) (o)",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSeasEOInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp + _infobox,
-            name = "Trident of the swamp",
+            name = "Trident of the Swamp",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSwampInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp_e + _infobox,
-            name = "Trident of the swamp (e)",
+            name = "Trident of the Swamp (e)",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSwampEInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp_o + _infobox,
-            name = "Trident of the swamp (o)",
+            name = "Trident of the Swamp (o)",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSwampOInfobox() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp_e_o + _infobox,
-            name = "Trident of the swamp (e) (o)",
+            name = "Trident of the Swamp (e) (o)",
             description = "",
             section = infoboxes
         ) default boolean tridentOfTheSwampEOInfobox() { return true; }
@@ -2332,56 +2332,56 @@ public interface TicTac7xChargesImprovedConfig extends Config {
 
         @ConfigItem(
             keyName = trident_of_the_seas + _overlay,
-            name = "Trident of the seas",
+            name = "Trident of the Seas",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSeasOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_seas_e + _overlay,
-            name = "Trident of the seas (e)",
+            name = "Trident of the Seas (e)",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSeasEOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_seas_o + _overlay,
-            name = "Trident of the seas (o)",
+            name = "Trident of the Seas (o)",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSeasOOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_seas_e_o + _overlay,
-            name = "Trident of the seas (e) (o)",
+            name = "Trident of the Seas (e) (o)",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSeasEOOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp + _overlay,
-            name = "Trident of the swamp",
+            name = "Trident of the Swamp",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSwampOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp_e + _overlay,
-            name = "Trident of the swamp (e)",
+            name = "Trident of the Swamp (e)",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSwampEOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp_o + _overlay,
-            name = "Trident of the swamp (o)",
+            name = "Trident of the Swamp (o)",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSwampOOverlay() { return true; }
 
         @ConfigItem(
             keyName = trident_of_the_swamp_e_o + _overlay,
-            name = "Trident of the swamp (e) (o)",
+            name = "Trident of the Swamp (e) (o)",
             description = "",
             section = overlays
         ) default boolean tridentOfTheSwampEOOverlay() { return true; }

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -442,7 +442,7 @@ public interface TicTac7xChargesImprovedConfig extends Config {
 
         @ConfigItem(
             keyName = pendant_of_ates + _infobox,
-            name = "Pendant of ates",
+            name = "Pendant of Ates",
             description = "",
             section = infoboxes
         ) default boolean pendantOfAtesInfobox() { return true; }
@@ -897,21 +897,21 @@ public interface TicTac7xChargesImprovedConfig extends Config {
 
         @ConfigItem(
             keyName = tome_of_earth + _infobox,
-            name = "Tome of earth",
+            name = "Tome of Earth",
             description = "",
             section = infoboxes
         ) default boolean tomeOfEarthInfobox() { return true; }
 
         @ConfigItem(
             keyName = tome_of_fire + _infobox,
-            name = "Tome of fire",
+            name = "Tome of Fire",
             description = "",
             section = infoboxes
         ) default boolean tomeOfFireInfobox() { return true; }
 
         @ConfigItem(
             keyName = tome_of_water + _infobox,
-            name = "Tome of water",
+            name = "Tome of Water",
             description = "",
             section = infoboxes
         ) default boolean tomeOfWaterInfobox() { return true; }
@@ -1485,7 +1485,7 @@ public interface TicTac7xChargesImprovedConfig extends Config {
 
         @ConfigItem(
             keyName = pendant_of_ates + _overlay,
-            name = "Pendant of ates",
+            name = "Pendant of Ates",
             description = "",
             section = overlays
         ) default boolean pendantOfAtesOverlay() { return true; }
@@ -2143,21 +2143,21 @@ public interface TicTac7xChargesImprovedConfig extends Config {
 
         @ConfigItem(
             keyName = tome_of_earth + _overlay,
-            name = "Tome of earth",
+            name = "Tome of Earth",
             description = "",
             section = overlays
         ) default boolean tomeOfEarthOverlay() { return true; }
 
         @ConfigItem(
             keyName = tome_of_fire + _overlay,
-            name = "Tome of fire",
+            name = "Tome of Fire",
             description = "",
             section = overlays
         ) default boolean tomeOfFireOverlay() { return true; }
 
         @ConfigItem(
             keyName = tome_of_water + _overlay,
-            name = "Tome of water",
+            name = "Tome of Water",
             description = "",
             section = overlays
         ) default boolean tomeOfWaterOverlay() { return true; }

--- a/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
@@ -52,7 +52,7 @@ public class H_SerpentineHelm extends ChargedItemWithStorage {
             new OnCombat(90).isEquipped().consumer(() -> storage.remove(ItemID.SNAKEBOSS_SCALE, 10)),
 
             // Auto-charge.
-            new OnAutoChargeMessage(itemName, "Zulrah scales", 1, this, ItemID.SNAKEBOSS_SCALE),
+            new OnAutoChargeMessage(itemName, "Zulrah's scales", 1, this, ItemID.SNAKEBOSS_SCALE),
 
             // Ran out of charges upon degrading in combat
             new OnChatMessage("Your serpentine helm has run out of Zulrah's scales.").consumer(() -> storage.clear())

--- a/src/main/java/tictac7x/charges/items/jewelry/J_PendantOfAtes.java
+++ b/src/main/java/tictac7x/charges/items/jewelry/J_PendantOfAtes.java
@@ -34,7 +34,7 @@ public class J_PendantOfAtes extends ChargedItem {
             new OnGraphicChanged(2754).decreaseCharges(1),
 
             // Auto-charge.
-            new OnAutoChargeMessage("Pendant of ates", "Frozen tear", 1, this),
+            new OnAutoChargeMessage("Pendant of Ates", "Frozen tear", 1, this),
 
             // Unified menu entry.
             new OnMenuEntryAdded("Rub").replaceOption("Teleport")

--- a/src/main/java/tictac7x/charges/items/shields/S_TomeOfEarth.java
+++ b/src/main/java/tictac7x/charges/items/shields/S_TomeOfEarth.java
@@ -25,7 +25,7 @@ public class S_TomeOfEarth extends ChargedItem {
             new OnGraphicChanged(96, 123, 138, 164, 1461).isEquipped().decreaseCharges(1),
 
             // Auto-charge.
-            new OnAutoChargeMessage("Tome of earth", "Soiled page", 20, this)
+            new OnAutoChargeMessage("Tome of Earth", "Soiled page", 20, this)
         ));
     }
 }

--- a/src/main/java/tictac7x/charges/items/shields/S_TomeOfFire.java
+++ b/src/main/java/tictac7x/charges/items/shields/S_TomeOfFire.java
@@ -25,7 +25,7 @@ public class S_TomeOfFire extends ChargedItem {
             new OnGraphicChanged(99, 126, 129, 155, 1464).isEquipped().decreaseCharges(1),
 
             // Auto-charge.
-            new OnAutoChargeMessage("Tome of fire", "Burnt page", 20, this)
+            new OnAutoChargeMessage("Tome of Fire", "Burnt page", 20, this)
         ));
     }
 }

--- a/src/main/java/tictac7x/charges/items/shields/S_TomeOfWater.java
+++ b/src/main/java/tictac7x/charges/items/shields/S_TomeOfWater.java
@@ -25,7 +25,7 @@ public class S_TomeOfWater extends ChargedItem {
             new OnGraphicChanged(93, 120, 135, 161, 1458).isEquipped().decreaseCharges(1),
 
             // Auto-charge.
-            new OnAutoChargeMessage("Tome of water", "Soaked page", 20, this)
+            new OnAutoChargeMessage("Tome of Water", "Soaked page", 20, this)
         ));
     }
 }

--- a/src/main/java/tictac7x/charges/items/weapons/W_BowOfFaerdhinen.java
+++ b/src/main/java/tictac7x/charges/items/weapons/W_BowOfFaerdhinen.java
@@ -34,7 +34,7 @@ public class W_BowOfFaerdhinen extends ChargedItem {
             new OnGraphicChanged(1888).isEquipped().decreaseCharges(1),
 
             // Auto-charge.
-            new OnAutoChargeMessage("Bow of faerdhinen", "Crystal shard", 100, this)
+            new OnAutoChargeMessage("Bow of Faerdhinen", "Crystal shard", 100, this)
         ));
     }
 }

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeas.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeas.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSeas extends _Trident {
             ItemID.TOTS_CHARGED,
             ItemID.TOTS_UNCHARGED,
             Optional.of(ItemID.TOTS),
-            "Trident of the seas",
+            "Trident of the Seas",
             1251,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeasE.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeasE.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSeasE extends _Trident {
             ItemID.TOTS_I_CHARGED,
             ItemID.TOTS_I_UNCHARGED,
             Optional.empty(),
-            "Trident of the seas (e)",
+            "Trident of the Seas (e)",
             1251,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeasEO.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeasEO.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSeasEO extends _Trident {
             ItemID.TOTS_I_CHARGED_ORN,
             ItemID.TOTS_I_UNCHARGED_ORN,
             Optional.empty(),
-            "Trident of the seas (e) (o)",
+            "Trident of the Seas (e) (o)",
             3721,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeasO.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSeasO.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSeasO extends _Trident {
             ItemID.TOTS_CHARGED_ORN,
             ItemID.TOTS_UNCHARGED_ORN,
             Optional.of(ItemID.TOTS_ORN),
-            "Trident of the seas (o)",
+            "Trident of the Seas (o)",
             3721,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwamp.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwamp.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSwamp extends _Trident {
             ItemID.TOXIC_TOTS_CHARGED,
             ItemID.TOXIC_TOTS_UNCHARGED,
             Optional.empty(),
-            "Trident of the swamp",
+            "Trident of the Swamp",
             665,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwampE.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwampE.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSwampE extends _Trident {
             ItemID.TOXIC_TOTS_I_CHARGED,
             ItemID.TOXIC_TOTS_I_UNCHARGED,
             Optional.empty(),
-            "Trident of the swamp (e)",
+            "Trident of the Swamp (e)",
             665,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwampEO.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwampEO.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSwampEO extends _Trident {
             ItemID.TOXIC_TOTS_I_CHARGED_ORN,
             ItemID.TOXIC_TOTS_I_UNCHARGED_ORN,
             Optional.empty(),
-            "Trident of the swamp (e) (o)",
+            "Trident of the Swamp (e) (o)",
             3722,
             provider
         );

--- a/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwampO.java
+++ b/src/main/java/tictac7x/charges/items/weapons/tridents/W_TridentOfTheSwampO.java
@@ -13,7 +13,7 @@ public class W_TridentOfTheSwampO extends _Trident {
             ItemID.TOXIC_TOTS_CHARGED_ORN,
             ItemID.TOXIC_TOTS_UNCHARGED_ORN,
             Optional.empty(),
-            "Trident of the swamp (o)",
+            "Trident of the Swamp (o)",
             3722,
             provider
         );


### PR DESCRIPTION
This fixes the spelling of some items from the August 19th update

- Trident of the **S**eas
- Trident of the **S**wamp
- Tome of **E**arth/**W**ater/**F**ire
- Pendant of **A**test

See #616